### PR TITLE
Fix jquery attribute equals selector.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.4 (unreleased)
 ------------------
 
+- Fix jquery attribute equals selector.
+  [elio.schmutz]
+
 - Add French and English translations.
   [jone]
 

--- a/ftw/notification/base/browser/notification_form.pt
+++ b/ftw/notification/base/browser/notification_form.pt
@@ -2,16 +2,16 @@
     <script>
         jQuery(function($){
             $('#all-to').click(function() {
-                $('input[name=to_list:list]').attr('checked', $(this).is(':checked'));
+                $('input[name="to_list:list"]').attr('checked', $(this).is(':checked'));
             });
             $('#all-cc').click(function() {
-                $('input[name=cc_list:list]').attr('checked', $(this).is(':checked'));
+                $('input[name="cc_list:list"]').attr('checked', $(this).is(':checked'));
             });
             $('#all-group-to').click(function() {
-                $('input[name=to_list_group:list]').attr('checked', $(this).is(':checked'));
+                $('input[name="to_list_group:list"]').attr('checked', $(this).is(':checked'));
             });
             $('#all-group-cc').click(function() {
-                $('input[name=cc_list_group:list]').attr('checked', $(this).is(':checked'));
+                $('input[name="cc_list_group:list"]').attr('checked', $(this).is(':checked'));
             });
         });
     </script>

--- a/ftw/notification/base/viewlets/notificationform.pt
+++ b/ftw/notification/base/viewlets/notificationform.pt
@@ -1,9 +1,9 @@
 <script>
     function select_recipients(checked){
-        jq('input[name=to_list:list]').attr('checked', checked);
+        jq('input[name="to_list:list"]').attr('checked', checked);
     }
-    
-    jq(function(){  
+
+    jq(function(){
         jq('#sendNotification').click(function(){
             var isChecked = jq('#sendNotification').attr('checked');
             if (!isChecked){
@@ -19,19 +19,19 @@
                 });
             }
         });
-        
+
     });
-    
+
 </script>
 
 <div class="field ArchetypesBooleanWidget" i18n:domain="ftw.notification.base">
-          
+
         <input type="checkbox" id="sendNotification" name="sendNotification:boolean" class="noborder" >
-      
+
           <label for="sendNotification" class="formQuestion" i18n:translate="label_send_notification">Send Notification</label>
-          
+
           <div id="sendNotification_help" class="formHelp" i18n:translate="help_notification">When selected a you can send a Notification after saving.</div>
-          
+
 </div>
 
 <div id="sendNotificationTo"><!--ie fix--></div>


### PR DESCRIPTION
@maethu 

![bildschirmfoto 2014-02-10 um 14 27 08](https://f.cloud.github.com/assets/557005/2125749/117e9494-9257-11e3-9d6e-d7aed546eb54.png)

JQuery API implementation: http://api.jquery.com/attribute-equals-selector/

closes #13
