### PR TITLE
New Feature "Show group members" does not work with https

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
+- Fixed show group members on notification view for https.
+  [lknoepfel]
+
 - Replaced deprecated jquery jq notation with $.
   [lknoepfel]
 

--- a/ftw/notification/base/browser/notification_form.pt
+++ b/ftw/notification/base/browser/notification_form.pt
@@ -16,7 +16,7 @@
             $('.showUsers').click(function(event) {
                 event.preventDefault();
                 self = $(this);
-                target = self.parent().find('.groupUsers');
+                target = self.closest('td').find('.groupUsers');
 
                 if (target.text().length > 0) {
                     target.toggle();
@@ -25,7 +25,7 @@
                     $.ajax({
                         url: 'notification_form_content/get_users_for_group?groupid='+groupid
                     }).done(function(data) {
-                        target.text(data)
+                        target.text(data);
                     });
                 }
             });


### PR DESCRIPTION
Check:
![screen shot 2014-08-13 at 10 08 48](https://cloud.githubusercontent.com/assets/437933/3902621/288800a8-22c1-11e4-9539-f3d189e10ede.png)

Plone wraps the link with a <span>. 

Since you are doing the `parent` method, with https it returns the wrapping span instead of the `td`.
This could be fixed by using. `self.closest('td').find.....`
