### PR TITLE
Fix bug when title is missing on user.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug when title is missing on user.
+  [lknoepfel]
 
 
 1.2.6 (2014-08-13)

--- a/ftw/notification/base/browser/views.py
+++ b/ftw/notification/base/browser/views.py
@@ -8,6 +8,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope import schema
 from zope.component import queryUtility
 from zope.i18n import translate
+from zope.schema.interfaces import ITitledTokenizedTerm
 
 
 def name_helper(item, value):
@@ -132,7 +133,8 @@ class NotificationForm(BrowserView):
                 if member is None:
                     continue
 
-                user = dict(title=t.title,
+                title = t.title if ITitledTokenizedTerm.providedBy(t) else t.value
+                user = dict(title=title,
                             value=t.value,
                             email=member.getProperty("email", ""),
                             selected=t.value in self.pre_select)


### PR DESCRIPTION
This bug happened on a customer installation. I couldn't reproduce the error locally or in a test. When i created a member without a title he was just ignored by the vocabulary (wasn't in the list).

The title in a term is optional. I added a check for that and a fallback to `value` if it is a titleless term.
https://github.com/starzel/plone.principalsource/blob/master/plone/principalsource/term.py#L12