### PR TITLE
Remove dependency on ftw.testing[splinter]

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.2.8 (unreleased)
 ------------------
 
+- Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]
+
 - Drop Plone 4.1 support. [jone]
 
 - Make notification form a view and add field to enable redirect to origin.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 version = '1.2.8.dev0'
 maintainer = 'Jonas Baumann'
 
-tests_require = ['ftw.testing [splinter]',
+tests_require = ['ftw.testing',
                  'ftw.builder',
                  'plone.app.testing',
                  'ftw.testbrowser',


### PR DESCRIPTION
This removes the dependency on the `ftw.testing[splinter]` extra, which has been [dropped from 
`ftw.testing`](https://github.com/4teamwork/ftw.testing/commit/6eadb49bed08a0b40113d65abf8b302935cb1007).