### PR TITLE
Use E-Mail instead of userid for notification form.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -25,7 +25,10 @@ import tempfile
 
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -35,13 +38,14 @@ Bootstraps a buildout-based project.
 Simply run this script in a directory containing a buildout.cfg, using the
 Python that you want bin/buildout to use.
 
-Note that by using --find-links to point to local resources, you can keep 
+Note that by using --find-links to point to local resources, you can keep
 this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -59,36 +63,57 @@ parser.add_option("-f", "--find-links",
 parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
-
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
 
 ######################################################################
 # load/install setuptools
 
 try:
-    if options.allow_site_packages:
-        import setuptools
-        import pkg_resources
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
 
 ez = {}
-exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
 if not options.allow_site_packages:
     # ez_setup imports site, which adds site packages
-    # this will remove them from the path to ensure that incompatible versions 
+    # this will remove them from the path to ensure that incompatible versions
     # of setuptools are not in the path
     import site
-    # inside a virtualenv, there is no 'getsitepackages'. 
+    # inside a virtualenv, there is no 'getsitepackages'.
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
         for sitepackage_path in site.getsitepackages():
-            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
 ez['use_setuptools'](**setup_args)
 import setuptools
 import pkg_resources
@@ -104,7 +129,12 @@ for path in sys.path:
 
 ws = pkg_resources.working_set
 
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
 cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
        'from setuptools.command.easy_install import main; main()',
        '-mZqNxd', tmpeggs]
 
@@ -117,21 +147,23 @@ find_links = os.environ.get(
 if find_links:
     cmd.extend(['-f', find_links])
 
-setuptools_path = ws.find(
-    pkg_resources.Requirement.parse('setuptools')).location
-
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
     _final_parts = '*final-', '*final'
 
     def _final_version(parsed_version):
-        for part in parsed_version:
-            if (part[:1] == '*') and (part not in _final_parts):
-                return False
-        return True
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
     index = setuptools.package_index.PackageIndex(
         search_path=[setuptools_path])
     if find_links:
@@ -156,7 +188,7 @@ if version:
 cmd.append(requirement)
 
 import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.2.8 (unreleased)
 ------------------
 
+- Drop Plone 4.2 support. [mathias.leimgruber]
+
 - Use E-Mail instead of userid for notification form. [mathias.leimgruber]
 
 - Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.2.8 (unreleased)
 ------------------
 
+- Use E-Mail instead of userid for notification form. [mathias.leimgruber]
+
 - Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]
 
 - Drop Plone 4.1 support. [jone]

--- a/ftw/notification/base/browser/views.py
+++ b/ftw/notification/base/browser/views.py
@@ -31,17 +31,17 @@ def checkbox_to_selected_helper(item, value):
         return u"""<input type="checkbox"
                           name="to_list:list"
                           checked="checked"
-                          value="%s"/>""" % item['value']
+                          value="%s"/>""" % item['email']
 
     return u"""<input type="checkbox"
                       name="to_list:list"
-                      value="%s"/>""" % item['value']
+                      value="%s"/>""" % item['email']
 
 
 def checkbox_cc_helper(item, value):
     return u"""<input type="checkbox"
                     name="cc_list:list"
-                    value="%s"/>""" % item['value']
+                    value="%s"/>""" % item['email']
 
 
 def checkbox_to_group_helper(item, value):
@@ -138,7 +138,7 @@ class NotificationForm(BrowserView):
                 title = t.title if ITitledTokenizedTerm.providedBy(t) else t.value
                 user = dict(title=title,
                             value=t.value,
-                            email=member.getProperty("email", ""),
+                            email=member.getProperty("email", t.value),
                             selected=t.value in self.pre_select)
                 finalized.append(user)
 

--- a/ftw/notification/base/tests/test_notification_form.py
+++ b/ftw/notification/base/tests/test_notification_form.py
@@ -4,7 +4,6 @@ from ftw.notification.base.browser.views import NotificationForm
 from ftw.notification.base.testing import FTW_N_BASE_INTEGRATION_TESTING
 from ftw.testbrowser import browser
 from unittest2 import TestCase
-from zope.component import getAdapter
 
 
 class TestNotificationForm(TestCase):
@@ -19,14 +18,14 @@ class TestNotificationForm(TestCase):
         self.user3 = create(Builder('user').named('User', 'Nr3'))
 
         self.group1 = create(Builder('group')
-            .with_groupid('group1')
-            .titled('Group1')
-            .with_members(self.user1, self.user2))
+                             .with_groupid('group1')
+                             .titled('Group1')
+                             .with_members(self.user1, self.user2))
 
         self.group2 = create(Builder('group')
-            .with_groupid('group2')
-            .titled('Group2')
-            .with_members(self.user2, self.user3))
+                             .with_groupid('group2')
+                             .titled('Group2')
+                             .with_members(self.user2, self.user3))
 
     def test_get_users_of_group(self):
         view = NotificationForm(self.portal, self.portal.REQUEST)

--- a/ftw/notification/base/tests/test_notification_form.py
+++ b/ftw/notification/base/tests/test_notification_form.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.notification.base.browser.views import NotificationForm
 from ftw.notification.base.testing import FTW_N_BASE_INTEGRATION_TESTING
+from ftw.testbrowser import browser
 from unittest2 import TestCase
 from zope.component import getAdapter
 
@@ -33,3 +34,14 @@ class TestNotificationForm(TestCase):
                           view.get_users_for_group('group1'))
         self.assertEquals('Nr2 User, Nr3 User',
                           view.get_users_for_group('group2'))
+
+    def test_use_email_property(self):
+        create(Builder('user').named('User', 'Nr4')
+               .with_userid('usernr4')
+               .having(email='test@example.com'))
+
+        view = NotificationForm(self.portal, self.portal.REQUEST)
+
+        browser.open_html(view.render_listing())
+        self.assertTrue(browser.css('[value="test@example.com"]'),
+                        'Expect to find the email address as value in table.')

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,10 @@ setup(name='ftw.notification.base',
       # http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],
 

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-
-package-name = ftw.notification.base


### PR DESCRIPTION
This worked a long time, since all our installations have userid==email==loginname.
But if the the loginname changed, the notification still went to the userid.

The bug was introduces in 2010 --> https://github.com/4teamwork/ftw.notification.base/commit/c6af3101ece4d1a38d4d6752f69f5238d47209c8#diff-998631dfd0022cb3bb27471ccb270a9eR14